### PR TITLE
Initiliased list options before all ListAll calls

### DIFF
--- a/internal/provider/datasource_domain.go
+++ b/internal/provider/datasource_domain.go
@@ -97,13 +97,13 @@ func (d *DomainDataSource) Read(ctx context.Context, req datasource.ReadRequest,
 		return
 	}
 
-	domains, err := d.cfClient.Domains.ListAll(ctx, &client.DomainListOptions{
-		Names: client.Filter{
-			Values: []string{
-				data.Name.ValueString(),
-			},
+	domainListOptions := client.NewDomainListOptions()
+	domainListOptions.Names = client.Filter{
+		Values: []string{
+			data.Name.ValueString(),
 		},
-	})
+	}
+	domains, err := d.cfClient.Domains.ListAll(ctx, domainListOptions)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"API Error Fetching Domain",

--- a/internal/provider/datasource_isolation_segment.go
+++ b/internal/provider/datasource_isolation_segment.go
@@ -73,15 +73,14 @@ func (d *IsolationSegmentDataSource) Read(ctx context.Context, req datasource.Re
 		return
 	}
 
-	getOptions := cfv3client.IsolationSegmentListOptions{
-		Names: cfv3client.Filter{
-			Values: []string{
-				data.Name.ValueString(),
-			},
+	getOptions := cfv3client.NewIsolationSegmentOptions()
+	getOptions.Names = cfv3client.Filter{
+		Values: []string{
+			data.Name.ValueString(),
 		},
 	}
 
-	isolationSegments, err := d.cfClient.IsolationSegments.ListAll(ctx, &getOptions)
+	isolationSegments, err := d.cfClient.IsolationSegments.ListAll(ctx, getOptions)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"API Error Fetching Isolation Segment.",

--- a/internal/provider/datasource_org.go
+++ b/internal/provider/datasource_org.go
@@ -84,13 +84,14 @@ func (d *OrgDataSource) Read(ctx context.Context, req datasource.ReadRequest, re
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	orgs, err := d.cfClient.Organizations.ListAll(ctx, &cfv3client.OrganizationListOptions{
-		Names: cfv3client.Filter{
-			Values: []string{
-				data.Name.ValueString(),
-			},
+
+	getOptions := cfv3client.NewOrganizationListOptions()
+	getOptions.Names = cfv3client.Filter{
+		Values: []string{
+			data.Name.ValueString(),
 		},
-	})
+	}
+	orgs, err := d.cfClient.Organizations.ListAll(ctx, getOptions)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Unable to fetch org data.",

--- a/internal/provider/datasource_org_quota.go
+++ b/internal/provider/datasource_org_quota.go
@@ -116,11 +116,14 @@ func (d *OrgQuotaDataSource) Read(ctx context.Context, req datasource.ReadReques
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	orgsQuotas, err := d.cfClient.OrganizationQuotas.ListAll(ctx, &cfv3client.OrganizationQuotaListOptions{
-		Names: cfv3client.Filter{
-			Values: []string{orgQuotaType.Name.ValueString()},
+
+	getOptions := cfv3client.NewOrganizationQuotaListOptions()
+	getOptions.Names = cfv3client.Filter{
+		Values: []string{
+			orgQuotaType.Name.ValueString(),
 		},
-	})
+	}
+	orgsQuotas, err := d.cfClient.OrganizationQuotas.ListAll(ctx, getOptions)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Unable to fetch org quota data.",

--- a/internal/provider/datasource_orgs.go
+++ b/internal/provider/datasource_orgs.go
@@ -89,7 +89,7 @@ func (d *OrgsDataSource) Read(ctx context.Context, req datasource.ReadRequest, r
 		return
 	}
 
-	orgsListOptions := &cfv3client.OrganizationListOptions{}
+	orgsListOptions := cfv3client.NewOrganizationListOptions()
 	if !data.Name.IsNull() {
 		orgsListOptions.Names = cfv3client.Filter{
 			Values: []string{

--- a/internal/provider/datasource_security_group.go
+++ b/internal/provider/datasource_security_group.go
@@ -127,13 +127,14 @@ func (d *SecurityGroupDataSource) Read(ctx context.Context, req datasource.ReadR
 		return
 	}
 
-	securityGroups, err := d.cfClient.SecurityGroups.ListAll(ctx, &client.SecurityGroupListOptions{
-		Names: client.Filter{
-			Values: []string{
-				data.Name.ValueString(),
-			},
+	getOptions := client.NewSecurityGroupListOptions()
+	getOptions.Names = client.Filter{
+		Values: []string{
+			data.Name.ValueString(),
 		},
-	})
+	}
+
+	securityGroups, err := d.cfClient.SecurityGroups.ListAll(ctx, getOptions)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"API Error Fetching Security Group",

--- a/internal/provider/datasource_service_credential_binding.go
+++ b/internal/provider/datasource_service_credential_binding.go
@@ -113,11 +113,10 @@ func (d *ServiceCredentialBindingDataSource) Read(ctx context.Context, req datas
 		return
 	}
 
-	getOptions := cfv3client.ServiceCredentialBindingListOptions{
-		ServiceInstanceGUIDs: cfv3client.Filter{
-			Values: []string{
-				data.ServiceInstance.ValueString(),
-			},
+	getOptions := cfv3client.NewServiceCredentialBindingListOptions()
+	getOptions.ServiceInstanceGUIDs = cfv3client.Filter{
+		Values: []string{
+			data.ServiceInstance.ValueString(),
 		},
 	}
 
@@ -136,7 +135,7 @@ func (d *ServiceCredentialBindingDataSource) Read(ctx context.Context, req datas
 		}
 	}
 
-	svcCredentialBindings, err := d.cfClient.ServiceCredentialBindings.ListAll(ctx, &getOptions)
+	svcCredentialBindings, err := d.cfClient.ServiceCredentialBindings.ListAll(ctx, getOptions)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"API Error Fetching Service Credential Binding.",

--- a/internal/provider/datasource_service_instance.go
+++ b/internal/provider/datasource_service_instance.go
@@ -117,14 +117,19 @@ func (d *ServiceInstanceDataSource) Read(ctx context.Context, req datasource.Rea
 		return
 	}
 
-	svcInstances, err := d.cfClient.ServiceInstances.ListAll(ctx, &cfv3client.ServiceInstanceListOptions{
-		Names: cfv3client.Filter{
-			Values: []string{data.Name.ValueString()},
+	getOptions := cfv3client.NewServiceInstanceListOptions()
+	getOptions.Names = cfv3client.Filter{
+		Values: []string{
+			data.Name.ValueString(),
 		},
-		SpaceGUIDs: cfv3client.Filter{
-			Values: []string{data.Space.ValueString()},
+	}
+	getOptions.SpaceGUIDs = cfv3client.Filter{
+		Values: []string{
+			data.Space.ValueString(),
 		},
-	})
+	}
+
+	svcInstances, err := d.cfClient.ServiceInstances.ListAll(ctx, getOptions)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"API Error to fetch service instance data.",

--- a/internal/provider/datasource_service_plans.go
+++ b/internal/provider/datasource_service_plans.go
@@ -209,7 +209,7 @@ func (d *ServicePlansDataSource) Read(ctx context.Context, req datasource.ReadRe
 		return
 	}
 
-	svcPlanOpts := &cfv3client.ServicePlanListOptions{}
+	svcPlanOpts := cfv3client.NewServicePlanListOptions()
 
 	if !data.Name.IsNull() {
 		svcPlanOpts.Names = cfv3client.Filter{

--- a/internal/provider/datasource_space.go
+++ b/internal/provider/datasource_space.go
@@ -108,19 +108,19 @@ func (d *SpaceDataSource) Read(ctx context.Context, req datasource.ReadRequest, 
 		return
 	}
 
+	splo := client.NewSpaceListOptions()
+	splo.OrganizationGUIDs = client.Filter{
+		Values: []string{
+			data.OrgId.ValueString(),
+		},
+	}
+	splo.Names = client.Filter{
+		Values: []string{
+			data.Name.ValueString(),
+		},
+	}
 	//Filtering for spaces under the org with GUID
-	spaces, err := d.cfClient.Spaces.ListAll(ctx, &client.SpaceListOptions{
-		OrganizationGUIDs: client.Filter{
-			Values: []string{
-				data.OrgId.ValueString(),
-			},
-		},
-		Names: client.Filter{
-			Values: []string{
-				data.Name.ValueString(),
-			},
-		},
-	})
+	spaces, err := d.cfClient.Spaces.ListAll(ctx, splo)
 
 	if err != nil {
 		resp.Diagnostics.AddError(

--- a/internal/provider/datasource_space_quota.go
+++ b/internal/provider/datasource_space_quota.go
@@ -122,11 +122,13 @@ func (d *SpaceQuotaDataSource) Read(ctx context.Context, req datasource.ReadRequ
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	sqlo := &cfv3client.SpaceQuotaListOptions{
-		Names: cfv3client.Filter{
-			Values: []string{spaceQuotaType.Name.ValueString()},
+	sqlo := cfv3client.NewSpaceQuotaListOptions()
+	sqlo.Names = cfv3client.Filter{
+		Values: []string{
+			spaceQuotaType.Name.ValueString(),
 		},
 	}
+
 	if !spaceQuotaType.Org.IsNull() {
 		sqlo.OrganizationGUIDs = cfv3client.Filter{
 			Values: []string{spaceQuotaType.Org.ValueString()},

--- a/internal/provider/datasource_spaces.go
+++ b/internal/provider/datasource_spaces.go
@@ -122,11 +122,10 @@ func (d *SpacesDataSource) Read(ctx context.Context, req datasource.ReadRequest,
 		return
 	}
 
-	spacesListOptions := client.SpaceListOptions{
-		OrganizationGUIDs: client.Filter{
-			Values: []string{
-				data.OrgId.ValueString(),
-			},
+	spacesListOptions := client.NewSpaceListOptions()
+	spacesListOptions.OrganizationGUIDs = client.Filter{
+		Values: []string{
+			data.OrgId.ValueString(),
 		},
 	}
 
@@ -139,7 +138,7 @@ func (d *SpacesDataSource) Read(ctx context.Context, req datasource.ReadRequest,
 	}
 
 	//Filtering for spaces under the org with GUID
-	spaces, err := d.cfClient.Spaces.ListAll(ctx, &spacesListOptions)
+	spaces, err := d.cfClient.Spaces.ListAll(ctx, spacesListOptions)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"API Error Fetching Spaces",

--- a/internal/provider/datasource_stack.go
+++ b/internal/provider/datasource_stack.go
@@ -88,13 +88,13 @@ func (d *StackDataSource) Read(ctx context.Context, req datasource.ReadRequest, 
 		return
 	}
 
-	stacks, err := d.cfClient.Stacks.ListAll(ctx, &client.StackListOptions{
-		Names: client.Filter{
-			Values: []string{
-				data.Name.ValueString(),
-			},
+	stlo := client.NewStackListOptions()
+	stlo.Names = client.Filter{
+		Values: []string{
+			data.Name.ValueString(),
 		},
-	})
+	}
+	stacks, err := d.cfClient.Stacks.ListAll(ctx, stlo)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"API Error Fetching Stack",

--- a/internal/provider/datasource_user.go
+++ b/internal/provider/datasource_user.go
@@ -93,13 +93,13 @@ func (d *UserDataSource) Read(ctx context.Context, req datasource.ReadRequest, r
 		return
 	}
 
-	users, err := d.cfClient.Users.ListAll(ctx, &client.UserListOptions{
-		UserNames: client.Filter{
-			Values: []string{
-				data.Name.ValueString(),
-			},
+	uslo := client.NewUserListOptions()
+	uslo.UserNames = client.Filter{
+		Values: []string{
+			data.Name.ValueString(),
 		},
-	})
+	}
+	users, err := d.cfClient.Users.ListAll(ctx, uslo)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"API Error Fetching Users",

--- a/internal/provider/resource_org.go
+++ b/internal/provider/resource_org.go
@@ -151,14 +151,13 @@ func (r *orgResource) Read(ctx context.Context, req resource.ReadRequest, resp *
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	orgs, err := r.cfClient.Organizations.ListAll(ctx, &cfv3client.OrganizationListOptions{
-		// will filter by ID as it already exists in state
-		GUIDs: cfv3client.Filter{
-			Values: []string{
-				data.ID.ValueString(),
-			},
+	orglo := cfv3client.NewOrganizationListOptions()
+	orglo.GUIDs = cfv3client.Filter{
+		Values: []string{
+			data.ID.ValueString(),
 		},
-	})
+	}
+	orgs, err := r.cfClient.Organizations.ListAll(ctx, orglo)
 	if err != nil {
 		handleReadErrors(ctx, resp, err, "org", data.ID.ValueString())
 		return

--- a/internal/provider/resource_org_quota.go
+++ b/internal/provider/resource_org_quota.go
@@ -156,11 +156,14 @@ func (r *orgQuotaResource) Read(ctx context.Context, req resource.ReadRequest, r
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	orgsQuotas, err := r.cfClient.OrganizationQuotas.ListAll(ctx, &cfv3client.OrganizationQuotaListOptions{
-		GUIDs: cfv3client.Filter{
-			Values: []string{orgQuotaTypeState.ID.ValueString()},
+
+	orgqulo := cfv3client.NewOrganizationQuotaListOptions()
+	orgqulo.GUIDs = cfv3client.Filter{
+		Values: []string{
+			orgQuotaTypeState.ID.ValueString(),
 		},
-	})
+	}
+	orgsQuotas, err := r.cfClient.OrganizationQuotas.ListAll(ctx, orgqulo)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Unable to fetch org quota data",

--- a/internal/provider/resource_space_quota.go
+++ b/internal/provider/resource_space_quota.go
@@ -164,11 +164,14 @@ func (r *spaceQuotaResource) Read(ctx context.Context, req resource.ReadRequest,
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	spacesQuotas, err := r.cfClient.SpaceQuotas.ListAll(ctx, &cfv3client.SpaceQuotaListOptions{
-		GUIDs: cfv3client.Filter{
-			Values: []string{spaceQuotaTypeState.ID.ValueString()},
+
+	spqulo := cfv3client.NewSpaceQuotaListOptions()
+	spqulo.GUIDs = cfv3client.Filter{
+		Values: []string{
+			spaceQuotaTypeState.ID.ValueString(),
 		},
-	})
+	}
+	spacesQuotas, err := r.cfClient.SpaceQuotas.ListAll(ctx, spqulo)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Unable to fetch space quota data",

--- a/internal/provider/types_route.go
+++ b/internal/provider/types_route.go
@@ -163,11 +163,10 @@ func mapDestinationValuesToSetType(ctx context.Context, destinations *[]resource
 // Sets the route list options for reading with cf-client from the terraform struct values.
 func (data *datasourceRouteType) mapReadRouteTypeToValues() client.RouteListOptions {
 
-	routeListOptions := client.RouteListOptions{
-		DomainGUIDs: client.Filter{
-			Values: []string{
-				data.Domain.ValueString(),
-			},
+	routeListOptions := client.NewRouteListOptions()
+	routeListOptions.DomainGUIDs = client.Filter{
+		Values: []string{
+			data.Domain.ValueString(),
 		},
 	}
 
@@ -187,7 +186,7 @@ func (data *datasourceRouteType) mapReadRouteTypeToValues() client.RouteListOpti
 		routeListOptions.OrganizationGUIDs = client.Filter{Values: []string{data.Org.ValueString()}}
 	}
 
-	return routeListOptions
+	return *routeListOptions
 }
 
 // Sets the route resource values for creation with cf-client from the terraform struct values.


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
- **Issue** - Multi page results returned by any ListAll call of the go-cfclient causes the provider to crash
- **Fix** - The ListAll function call takes an optional filtering parameters object. Populating or initialising the ListOptions attribute of the object ensures multi page results are processed without any issue. So this PR aims to call the functions required to initialise ListOptions attribute in every object before the ListAll calls are invoked.


## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No


## Pull Request Type

What kind of change does this Pull Request introduce?
<!-- Please check the one that applies to this PR using "X". -->

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:


## How to Test

- Test the code via automated test

```bash
go test ./...
```

<!-- Add additional steps if applicable -->
- Additional test steps

```
...
```

## What to Check

Verify that the following are valid:

- Automated tests are executed successfully
<!-- Add additional conditions if applicable -->
- ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->

## Checklist for reviewer

<!-- This checklist needs to completed by the reviewer of the PR -->
The following organizational tasks must be completed before merging this PR:

- [ ] The PR is assigned to the Terraform project and a status is set (typically "in review").
- [ ] The PR has the matching labels assigned to it.
- [ ] The PR has a milestone assigned to it.
- [ ] If the PR closes an issue, the issue is referenced.
- [ ] Possible follow-up items are created and linked.
