### PR TITLE
update documentation for cloudfoundry_org_role resource

### DIFF
--- a/docs/resources/org_role.md
+++ b/docs/resources/org_role.md
@@ -44,7 +44,7 @@ resource "cloudfoundry_org_role" "my_role" {
 Import is supported using the following syntax:
 
 ```terraform
-# terraform import cloudfoundry_role.<resource_name> <role_guid>
+# terraform import cloudfoundry_org_role.<resource_name> <role_guid>
 
-terraform import cloudfoundry_role.my_role e17839d9-cd4f-4e4b-baf0-18786f12fede
+terraform import cloudfoundry_org_role.my_role e17839d9-cd4f-4e4b-baf0-18786f12fede
 ```

--- a/examples/resources/cloudfoundry_org_role/import.sh
+++ b/examples/resources/cloudfoundry_org_role/import.sh
@@ -1,3 +1,3 @@
-# terraform import cloudfoundry_role.<resource_name> <role_guid>
+# terraform import cloudfoundry_org_role.<resource_name> <role_guid>
 
-terraform import cloudfoundry_role.my_role e17839d9-cd4f-4e4b-baf0-18786f12fede
+terraform import cloudfoundry_org_role.my_role e17839d9-cd4f-4e4b-baf0-18786f12fede


### PR DESCRIPTION
## Purpose
- The current documentation for the cloudfoundry_org_role resource includes the incorrect import statement:

`# terraform import cloudfoundry_role.<resource_name> <role_guid>`

This PR updated it to:

`# terraform import cloudfoundry_org_role.<resource_name> <role_guid>`

closes #86 

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No


## Pull Request Type

What kind of change does this Pull Request introduce?
<!-- Please check the one that applies to this PR using "X". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [x] Documentation content changes
- [ ] Other... Please describe:


## How to Test

- Test the code via automated test

```bash
go test ./...
```

<!-- Add additional steps if applicable -->
- Additional test steps

```
...
```

## What to Check

Verify that the following are valid:

- Automated tests are executed successfully
<!-- Add additional conditions if applicable -->
- ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->

## Checklist for reviewer

<!-- This checklist needs to completed by the reviewer of the PR -->
The following organizational tasks must be completed before merging this PR:

- [ ] The PR is assigned to the Terraform project and a status is set (typically "in review").
- [ ] The PR has the matching labels assigned to it.
- [ ] The PR has a milestone assigned to it.
- [ ] If the PR closes an issue, the issue is referenced.
- [ ] Possible follow-up items are created and linked.
