### PR TITLE
feat: add module as parameter for mta resource

### DIFF
--- a/docs/resources/mta.md
+++ b/docs/resources/mta.md
@@ -83,6 +83,7 @@ EOT
 - `deploy_url` (String) The URL of the deploy service, if a custom one has been used(should be present in the same landscape). By default 'deploy-service.<system-domain>'
 - `extension_descriptors` (Set of String) The paths for the MTA deployment extension files.
 - `extension_descriptors_string` (Set of String) The contents of the MTA deployment extension files.
+- `modules` (Set of String) Deploy only the modules of the MTA with the specified names. If not specified, all modules are deployed.
 - `mtar_path` (String) The local path where the MTA archive is present. Either this attribute or mtar_url need to be set.
 - `mtar_url` (String) The remote URL where the MTA archive is present
 - `namespace` (String) The namespace of the MTA. Should be of valid host format

--- a/internal/provider/datasource_mtas_test.go
+++ b/internal/provider/datasource_mtas_test.go
@@ -34,6 +34,7 @@ type MtaResourceModelPtr struct {
 	SourceCodeHash             *string
 	DeployStrategy             *string
 	VersionRule                *string
+	Modules                    *string
 }
 
 func hclDataSourceMtas(mdsmp *MtasDataSourceModelPtr) string {
@@ -106,6 +107,9 @@ func hclResourceMta(mrmp *MtaResourceModelPtr) string {
 			{{- end -}}
 			{{if .VersionRule}}
 				version_rule = "{{.VersionRule}}"
+			{{- end -}}
+			{{if .Modules}}
+				modules = {{.Modules}}
 			{{- end -}}
 			{{if .DeployUrl}}
 				deploy_url = "{{.DeployUrl}}"

--- a/internal/provider/resource_mta.go
+++ b/internal/provider/resource_mta.go
@@ -130,6 +130,14 @@ __Note:__
 					stringvalidator.OneOf("HIGHER", "SAME_HIGHER", "ALL"),
 				},
 			},
+			"modules": schema.SetAttribute{
+				MarkdownDescription: "Deploy only the modules of the MTA with the specified names. If not specified, all modules are deployed.",
+				Optional:            true,
+				ElementType:         types.StringType,
+				Validators: []validator.Set{
+					setvalidator.SizeAtLeast(1),
+				},
+			},
 			"mta": schema.SingleNestedAttribute{
 				MarkdownDescription: "contains the details of the MTA object",
 				Computed:            true,
@@ -393,6 +401,14 @@ func (r *mtaResource) upsert(ctx context.Context, reqPlan *tfsdk.Plan, reqState 
 
 	if extensionDescriptors != "" {
 		operationParams.Parameters["mtaExtDescriptorId"] = extensionDescriptors
+	}
+
+	if !mtarType.Modules.IsNull() {
+		var modules []string
+		diags = mtarType.Modules.ElementsAs(ctx, &modules, false)
+		respDiags.Append(diags...)
+
+		operationParams.Parameters["modulesForDeployment"] = strings.Join(modules, ",")
 	}
 
 	//Starting deploy operation

--- a/internal/provider/resource_mta_test.go
+++ b/internal/provider/resource_mta_test.go
@@ -20,6 +20,7 @@ func TestMtaResource_Configure(t *testing.T) {
 		normalDeploy               = "deploy"
 		bgDeploy                   = "blue-green-deploy"
 		versionRuleAll             = "ALL"
+		modules                    = `["my-app"]`
 		extensionDescriptorsString = `[
     <<EOT
 _schema-version: 3.3.0
@@ -129,6 +130,7 @@ EOT
 						ExtensionDescriptors: strtostrptr(extensionDescriptors),
 						DeployStrategy:       strtostrptr(normalDeploy),
 						VersionRule:          strtostrptr(versionRuleAll),
+						Modules:              strtostrptr(modules),
 					}),
 					Check: resource.ComposeAggregateTestCheckFunc(
 						resource.TestCheckResourceAttr(resourceName, "mtar_path", mtarPath2),

--- a/internal/provider/types_mta.go
+++ b/internal/provider/types_mta.go
@@ -22,6 +22,7 @@ type MtarType struct {
 	SourceCodeHash             types.String `tfsdk:"source_code_hash"`
 	DeployStrategy             types.String `tfsdk:"deploy_strategy"`
 	VersionRule                types.String `tfsdk:"version_rule"`
+	Modules                    types.Set    `tfsdk:"modules"`
 }
 
 type MtasDataSourceType struct {


### PR DESCRIPTION
Allows specifying modules that should be deployed.

## Purpose

It adds a new optional parameter for the `mta` CF resource to specify modules that should be deployed.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No


## Pull Request Type

What kind of change does this Pull Request introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:


## How to Test

- Test the code via automated test

```bash
go test ./...
```

## What to Check

Verify that the following are valid:

- Automated tests are executed successfully


## Other Information
<!-- Add any other helpful information that may be needed here. -->

## Checklist for reviewer

<!-- This checklist needs to completed by the reviewer of the PR -->
The following organizational tasks must be completed before merging this PR:

- [ ] The PR is assigned to the Terraform project and a status is set (typically "in review").
- [ ] The PR has the matching labels assigned to it.
- [ ] The PR has a milestone assigned to it.
- [ ] If the PR closes an issue, the issue is referenced.
- [ ] Possible follow-up items are created and linked.
