### PR TITLE
fix : Space quota resource destruction bug fix

### DIFF
--- a/docs/resources/space_quota.md
+++ b/docs/resources/space_quota.md
@@ -2,12 +2,12 @@
 page_title: "cloudfoundry_space_quota Resource - terraform-provider-cloudfoundry"
 subcategory: ""
 description: |-
-  Provides a Cloud Foundry resource to manage space quota definitions.
+  Provides a Cloud Foundry resource to manage space quota definitions. Only spaces assigned via Terraform are managed. On deletion, Terraform removes these assignments before deleting the quota. Non-Terraform managed assignments are not removed, which may cause deletion to fail.
 ---
 
 # cloudfoundry_space_quota (Resource)
 
-Provides a Cloud Foundry resource to manage space quota definitions.
+Provides a Cloud Foundry resource to manage space quota definitions. Only spaces assigned via Terraform are managed. On deletion, Terraform removes these assignments before deleting the quota. Non-Terraform managed assignments are not removed, which may cause deletion to fail.
 
 ## Example Usage
 

--- a/internal/provider/resource_security_group_space_bindings.go
+++ b/internal/provider/resource_security_group_space_bindings.go
@@ -248,9 +248,6 @@ func (rs *SecurityGroupSpacesResource) Update(ctx context.Context, req resource.
 	diags = plan.mapSecurityGroupSpacesValuestoType(ctx, runningSpaces, stagingSpaces)
 	resp.Diagnostics.Append(diags...)
 
-	diags = plan.mapSecurityGroupSpacesValuestoType(ctx, runningSpaces, stagingSpaces)
-	resp.Diagnostics.Append(diags...)
-
 	tflog.Trace(ctx, "updated a security group spaces resource")
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 }


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
- Fixes : #227
- Fixed space quota deletion logic:
  -Terraform-managed space assignments are now removed before deleting the quota.
   -Deletion fails if non-Terraform-managed space assignments still exist.
- Skipped non-Terraform managed space assignments during deletion to avoid unintended changes.
- Refactored repeated code in the resource_security_group_space_bindings.go .


## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No


## Pull Request Type

What kind of change does this Pull Request introduce?
<!-- Please check the one that applies to this PR using "X". -->

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:


## How to Test

- Test the code via automated test

```bash
go test ./...
```



## What to Check

Verify that the following are valid:

- Automated tests are executed successfully
<!-- Add additional conditions if applicable -->

## Other Information
<!-- Add any other helpful information that may be needed here. -->

## Checklist for reviewer

<!-- This checklist needs to completed by the reviewer of the PR -->
The following organizational tasks must be completed before merging this PR:

- [ ] The PR is assigned to the Terraform project and a status is set (typically "in review").
- [ ] The PR has the matching labels assigned to it.
- [ ] The PR has a milestone assigned to it.
- [ ] If the PR closes an issue, the issue is referenced.
- [ ] Possible follow-up items are created and linked.
