### PR TITLE
fix : Inconsistent apply with resources app and service_credential_binding bug fix

### DIFF
--- a/docs/resources/app.md
+++ b/docs/resources/app.md
@@ -220,13 +220,10 @@ Optional:
 <a id="nestedatt--service_bindings"></a>
 ### Nested Schema for `service_bindings`
 
-Required:
-
-- `service_instance` (String) The service instance name.
-
 Optional:
 
 - `params` (String) A json object to send to the service broker during service binding.
+- `service_instance` (String) The service instance name.
 
 
 <a id="nestedatt--sidecars"></a>

--- a/internal/provider/resource_app.go
+++ b/internal/provider/resource_app.go
@@ -141,8 +141,10 @@ func (r *appResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *
 			"service_bindings": schema.SetNestedAttribute{
 				MarkdownDescription: "Service instances to bind to the application.",
 				Optional:            true,
+				Computed:            true,
 				Validators: []validator.Set{
 					setvalidator.SizeAtLeast(1),
+					setvalidator.AlsoRequires(path.MatchRoot("service_bindings").AtAnySetValue().AtName("service_instance")),
 				},
 				PlanModifiers: []planmodifier.Set{
 					setplanmodifier.RequiresReplace(),
@@ -151,12 +153,14 @@ func (r *appResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *
 					Attributes: map[string]schema.Attribute{
 						"service_instance": schema.StringAttribute{
 							MarkdownDescription: "The service instance name.",
-							Required:            true,
+							Optional:            true,
+							Computed:            true,
 						},
 						"params": schema.StringAttribute{
 							CustomType:          jsontypes.NormalizedType{},
 							MarkdownDescription: "A json object to send to the service broker during service binding.",
 							Optional:            true,
+							Computed:            true,
 						},
 					},
 				},

--- a/internal/provider/types_app.go
+++ b/internal/provider/types_app.go
@@ -434,6 +434,7 @@ func mapAppValuesToType(ctx context.Context, appManifest *cfv3operation.AppManif
 			serviceBindings = append(serviceBindings, sb)
 		}
 		appType.ServiceBindings, tempDiags = types.SetValueFrom(ctx, serviceBindingObjType, serviceBindings)
+		diags = append(diags, tempDiags...)
 	} else {
 		appType.ServiceBindings = types.SetNull(serviceBindingObjType)
 	}


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
- Fixes : #212 
- Handled issue where terraform apply triggered unnecessary destroy and recreate of cloudfoundry_app and cloudfoundry_service_credential_binding despite no configuration changes.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No


## Pull Request Type

What kind of change does this Pull Request introduce?
<!-- Please check the one that applies to this PR using "X". -->

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:


## How to Test

- Test the code via automated test

```bash
go test ./...
```

<!-- Add additional steps if applicable -->
- Additional test steps

```
...
```

## What to Check

Verify that the following are valid:

- Automated tests are executed successfully
<!-- Add additional conditions if applicable -->
- ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->

## Checklist for reviewer

<!-- This checklist needs to completed by the reviewer of the PR -->
The following organizational tasks must be completed before merging this PR:

- [ ] The PR is assigned to the Terraform project and a status is set (typically "in review").
- [ ] The PR has the matching labels assigned to it.
- [ ] The PR has a milestone assigned to it.
- [ ] If the PR closes an issue, the issue is referenced.
- [ ] Possible follow-up items are created and linked.
