### PR TITLE
Fix service instance update with new service plan

### DIFF
--- a/internal/provider/resource_service_instance.go
+++ b/internal/provider/resource_service_instance.go
@@ -451,6 +451,7 @@ func (r *serviceInstanceResource) Update(ctx context.Context, req resource.Updat
 		if plan.Name.ValueString() != previousState.Name.ValueString() {
 			updateServiceInstance.Name = plan.Name.ValueStringPointer()
 		}
+		//Check if service plan is different from the previous state
 		if plan.ServicePlan.ValueString() != previousState.ServicePlan.ValueString() {
 			updateServiceInstance.Relationships = &cfv3resource.ServiceInstanceRelationships{
 				ServicePlan: &cfv3resource.ToOneRelationship{
@@ -460,7 +461,6 @@ func (r *serviceInstanceResource) Update(ctx context.Context, req resource.Updat
 				},
 			}
 		}
-
 		if !plan.Parameters.IsNull() {
 			var params json.RawMessage
 			err := json.Unmarshal([]byte(plan.Parameters.ValueString()), &params)

--- a/internal/provider/resource_service_instance.go
+++ b/internal/provider/resource_service_instance.go
@@ -451,23 +451,7 @@ func (r *serviceInstanceResource) Update(ctx context.Context, req resource.Updat
 		if plan.Name.ValueString() != previousState.Name.ValueString() {
 			updateServiceInstance.Name = plan.Name.ValueStringPointer()
 		}
-		// Check if the service plan is different from the previous state
 		if plan.ServicePlan.ValueString() != previousState.ServicePlan.ValueString() {
-			ok, err := isServiceInstanceUpgradable(ctx, previousState.ID.ValueString(), *r.cfClient)
-			if err != nil {
-				resp.Diagnostics.AddError(
-					"Error in checking service instance upgradability",
-					"Unable to check service instance upgradability"+plan.Name.ValueString()+": "+err.Error(),
-				)
-				return
-			}
-			if !ok {
-				resp.Diagnostics.AddError(
-					"Service instance not upgradable",
-					"Service instance "+plan.Name.ValueString()+" is not upgradable",
-				)
-				return
-			}
 			updateServiceInstance.Relationships = &cfv3resource.ServiceInstanceRelationships{
 				ServicePlan: &cfv3resource.ToOneRelationship{
 					Data: &cfv3resource.Relationship{
@@ -476,6 +460,7 @@ func (r *serviceInstanceResource) Update(ctx context.Context, req resource.Updat
 				},
 			}
 		}
+
 		if !plan.Parameters.IsNull() {
 			var params json.RawMessage
 			err := json.Unmarshal([]byte(plan.Parameters.ValueString()), &params)

--- a/internal/provider/types_service_instance.go
+++ b/internal/provider/types_service_instance.go
@@ -2,15 +2,13 @@ package provider
 
 import (
 	"context"
-	"time"
-
-	cfv3client "github.com/cloudfoundry/go-cfclient/v3/client"
 	"github.com/cloudfoundry/go-cfclient/v3/resource"
 	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"time"
 )
 
 type serviceInstanceType struct {
@@ -273,16 +271,6 @@ func mapMaintenanceInfo(value resource.ServiceInstanceMaintenanceInfo) maintenan
 
 	return maintenance
 
-}
-
-// isServiceInstanceUpgradable checks if the service instance is upgradable
-// some service instances may not be upgradable.
-func isServiceInstanceUpgradable(ctx context.Context, guid string, c cfv3client.Client) (bool, error) {
-	svc, err := c.ServiceInstances.Get(ctx, guid)
-	if err != nil {
-		return false, err
-	}
-	return svc.UpgradeAvailable != nil && *svc.UpgradeAvailable, nil
 }
 
 // toTagsList converts aliases of type types.Set into a slice of strings.


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
- Fixes #240 
- Previously, updating a service instance with a new service plan would fail stating service is not upgradable and not apply the change.
- This PR modifies the Update function to correctly handle plan updates:
  - If the plan is updatable, the instance is updated successfully.
  - If not, a clear error is returned indicating the plan cannot be changed.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No


## Pull Request Type

What kind of change does this Pull Request introduce?
<!-- Please check the one that applies to this PR using "X". -->

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:


## How to Test

- Test the code via automated test

```bash
go test ./...
```

<!-- Add additional steps if applicable -->
- Additional test steps

```
...
```

## What to Check

Verify that the following are valid:

- Automated tests are executed successfully
<!-- Add additional conditions if applicable -->

## Other Information
<!-- Add any other helpful information that may be needed here. -->

## Checklist for reviewer

<!-- This checklist needs to completed by the reviewer of the PR -->
The following organizational tasks must be completed before merging this PR:

- [ ] The PR is assigned to the Terraform project and a status is set (typically "in review").
- [ ] The PR has the matching labels assigned to it.
- [ ] The PR has a milestone assigned to it.
- [ ] If the PR closes an issue, the issue is referenced.
- [ ] Possible follow-up items are created and linked.
