### PR TITLE
Fix process set reconciliation when reading cloudfoundry_app

### DIFF
--- a/cloudfoundry/provider/types_app.go
+++ b/cloudfoundry/provider/types_app.go
@@ -460,7 +460,7 @@ func mapAppValuesToType(ctx context.Context, appManifest *cfv3operation.AppManif
 		appType.Environment = types.MapNull(types.StringType)
 	}
 	if appManifest.Processes != nil {
-		planProcessesByType := map[string]*Process{}
+		var planProcessesByType map[string]*Process
 		if reqPlanType != nil && len(reqPlanType.Processes) > 0 {
 			planProcessesByType = make(map[string]*Process, len(reqPlanType.Processes))
 			for i := range reqPlanType.Processes {


### PR DESCRIPTION
## Purpose
* Fix resource_app: look up planned processes by type when mapping API responses back into Terraform state.
  * Prevents “Provider produced inconsistent result after apply” when Cloud Foundry reorders process definitions. 

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No


## Pull Request Type

What kind of change does this Pull Request introduce?
<!-- Please check the one that applies to this PR using "X". -->

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:


## How to Test

- Test the code via automated test

```bash
go test ./...
```

## What to Check

Verify that the following are valid:

- Automated tests are executed successfully

## Other Information

Example post-apply output prior to this fix:
```
╷
│ Error: Provider produced inconsistent result after apply
│
│ When applying changes to module.workflow.module.workflow.cloudfoundry_app.backend, provider "provider[\"registry.terraform.io/cloudfoundry/cloudfoundry\"]" produced an
│ unexpected new value: .processes: planned set element cty.ObjectVal(map[string]cty.Value{"command":cty.StringVal("bash -c 'source .profile && ./bin/boot_server_in_docker'"),
│ "disk_quota":cty.StringVal("1024M"), "health_check_http_endpoint":cty.StringVal("/api/v1.0/status"), "health_check_interval":cty.NullVal(cty.Number),
│ "health_check_invocation_timeout":cty.NullVal(cty.Number), "health_check_type":cty.StringVal("http"), "instances":cty.NumberIntVal(1),
│ "log_rate_limit_per_second":cty.UnknownVal(cty.String), "memory":cty.StringVal("1G"), "readiness_health_check_http_endpoint":cty.NullVal(cty.String),
│ "readiness_health_check_interval":cty.NullVal(cty.Number), "readiness_health_check_invocation_timeout":cty.NullVal(cty.Number),
│ "readiness_health_check_type":cty.UnknownVal(cty.String), "timeout":cty.NullVal(cty.Number), "type":cty.StringVal("web")}) does not correlate with any element in actual.
│
│ This is a bug in the provider, which should be reported in the provider's own issue tracker.
╵
```

## Checklist for reviewer

<!-- This checklist needs to completed by the reviewer of the PR -->
The following organizational tasks must be completed before merging this PR:

- [ ] The PR has the matching labels assigned to it.
- [x] The PR has a milestone assigned to it.
- [x] If the PR closes an issue, the issue is referenced.
- [x] Possible follow-up items are created and linked.
