### PR TITLE
fix: provider crash when retrieving apps with datasource_apps

### DIFF
--- a/cloudfoundry/provider/datasource_app.go
+++ b/cloudfoundry/provider/datasource_app.go
@@ -306,7 +306,7 @@ func (d *appDataSource) Read(ctx context.Context, req datasource.ReadRequest, re
 		resp.Diagnostics.AddError("Error unmarshalling app", err.Error())
 		return
 	}
-	atResp, diags := mapAppDatasourceValuesToType(ctx, appManifest.Applications[0], app, nil, sshResp)
+	atResp, diags := mapAppDatasourceValuesToType(ctx, appManifest.Applications[0], app, sshResp)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/cloudfoundry/provider/datasource_apps.go
+++ b/cloudfoundry/provider/datasource_apps.go
@@ -293,7 +293,7 @@ func (d *appsDataSource) Read(ctx context.Context, req datasource.ReadRequest, r
 			return
 		}
 
-		atResp, diags := mapAppDatasourceValuesToType(ctx, appManifest.Applications[0], app, nil, sshResp)
+		atResp, diags := mapAppDatasourceValuesToType(ctx, appManifest.Applications[0], app, sshResp)
 		resp.Diagnostics.Append(diags...)
 		if resp.Diagnostics.HasError() {
 			return

--- a/cloudfoundry/provider/types_app.go
+++ b/cloudfoundry/provider/types_app.go
@@ -739,7 +739,7 @@ func setEnvForUpdate(ctx context.Context, existingEnvs basetypes.MapValue, plann
 	return finalEnvs, diagnostics
 }
 
-func mapAppDatasourceValuesToType(ctx context.Context, appManifest *cfv3operation.AppManifest, app *cfv3resource.App, reqPlanType *AppType, sshResp *cfv3resource.AppFeature) (DatasourceAppType, diag.Diagnostics) {
+func mapAppDatasourceValuesToType(ctx context.Context, appManifest *cfv3operation.AppManifest, app *cfv3resource.App, sshResp *cfv3resource.AppFeature) (DatasourceAppType, diag.Diagnostics) {
 	var diags, tempDiags diag.Diagnostics
 	var appType DatasourceAppType
 	appType.Name = types.StringValue(appManifest.Name)


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
- This PR fixes a runtime crash that occurs when using the data.cloudfoundry_apps data source in configuration where at least one application was pushed from a Docker image with --docker-username.
- closes #340 

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No


## Pull Request Type

What kind of change does this Pull Request introduce?
<!-- Please check the one that applies to this PR using "X". -->

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:


## How to Test

- Test the code via automated test

```bash
go test ./...
```

## What to Check

Verify that the following are valid:

- Automated tests are executed successfully

## Other Information
<!-- Add any other helpful information that may be needed here. -->

## Checklist for reviewer

<!-- This checklist needs to completed by the reviewer of the PR -->
The following organizational tasks must be completed before merging this PR:

- [x] The PR has the matching labels assigned to it.
- [x] The PR has a milestone assigned to it.
- [x] If the PR closes an issue, the issue is referenced.
- [x] Possible follow-up items are created and linked.
