### PR TITLE
fix: align mta resource with multiapps-cli

### DIFF
--- a/cloudfoundry/provider/resource_mta_test.go
+++ b/cloudfoundry/provider/resource_mta_test.go
@@ -17,8 +17,7 @@ func TestMtaResource_Configure(t *testing.T) {
 		mtarUrl                    = "https://github.com/Dray56/mtar-archive/releases/download/v1.0.0/a.cf.app.mtar"
 		extensionDescriptors       = `["../../assets/prod.mtaext","../../assets/prod-scale-vertically.mtaext"]`
 		sourceCodeHash             = "fca8f8d1c499a1d0561c274ab974faf09355d513bb36475fe67577d850562801"
-		normalDeploy               = "deploy"
-		bgDeploy                   = "blue-green-deploy"
+		bgDeploy                   = "blue-green"
 		versionRuleAll             = "ALL"
 		modules                    = `["my-app"]`
 		extensionDescriptorsString = `[
@@ -65,13 +64,12 @@ EOT
 			Steps: []resource.TestStep{
 				{
 					Config: hclProvider(nil) + hclResourceMta(&MtaResourceModelPtr{
-						HclType:        hclObjectResource,
-						HclObjectName:  "rs",
-						MtarPath:       strtostrptr(mtarPath),
-						Space:          strtostrptr(spaceGuid),
-						Namespace:      strtostrptr(namespace),
-						DeployStrategy: strtostrptr(normalDeploy),
-						VersionRule:    strtostrptr(versionRuleAll),
+						HclType:       hclObjectResource,
+						HclObjectName: "rs",
+						MtarPath:      strtostrptr(mtarPath),
+						Space:         strtostrptr(spaceGuid),
+						Namespace:     strtostrptr(namespace),
+						VersionRule:   strtostrptr(versionRuleAll),
 					}),
 					Check: resource.ComposeAggregateTestCheckFunc(
 						resource.TestCheckResourceAttr(resourceName, "mtar_path", mtarPath),
@@ -81,12 +79,11 @@ EOT
 				},
 				{
 					Config: hclProvider(nil) + hclResourceMta(&MtaResourceModelPtr{
-						HclType:        hclObjectResource,
-						HclObjectName:  "rs",
-						MtarUrl:        strtostrptr(mtarUrl),
-						Space:          strtostrptr(spaceGuid),
-						Namespace:      strtostrptr(namespace),
-						DeployStrategy: strtostrptr(normalDeploy),
+						HclType:       hclObjectResource,
+						HclObjectName: "rs",
+						MtarUrl:       strtostrptr(mtarUrl),
+						Space:         strtostrptr(spaceGuid),
+						Namespace:     strtostrptr(namespace),
 					}),
 					Check: resource.ComposeAggregateTestCheckFunc(
 						resource.TestCheckResourceAttr(resourceName, "mtar_url", mtarUrl),
@@ -103,7 +100,6 @@ EOT
 						Space:                strtostrptr(spaceGuid),
 						Namespace:            strtostrptr(namespace),
 						ExtensionDescriptors: strtostrptr(extensionDescriptors),
-						DeployStrategy:       strtostrptr(normalDeploy),
 					}),
 					ExpectError: regexp.MustCompile(`Error: New MTA ID`),
 				},
@@ -128,7 +124,6 @@ EOT
 						Space:                strtostrptr(spaceGuid),
 						Namespace:            strtostrptr(namespace),
 						ExtensionDescriptors: strtostrptr(extensionDescriptors),
-						DeployStrategy:       strtostrptr(normalDeploy),
 						VersionRule:          strtostrptr(versionRuleAll),
 						Modules:              strtostrptr(modules),
 					}),
@@ -191,31 +186,28 @@ EOT
 			Steps: []resource.TestStep{
 				{
 					Config: hclProvider(nil) + hclResourceMta(&MtaResourceModelPtr{
-						HclType:        hclObjectResource,
-						HclObjectName:  "rs",
-						Space:          strtostrptr(spaceGuid),
-						MtarPath:       strtostrptr(invalidOrgGUID),
-						DeployStrategy: strtostrptr(normalDeploy),
+						HclType:       hclObjectResource,
+						HclObjectName: "rs",
+						Space:         strtostrptr(spaceGuid),
+						MtarPath:      strtostrptr(invalidOrgGUID),
 					}),
 					ExpectError: regexp.MustCompile(`Unable to upload mtar file`),
 				},
 				{
 					Config: hclProvider(nil) + hclResourceMta(&MtaResourceModelPtr{
-						HclType:        hclObjectResource,
-						HclObjectName:  "rs",
-						Space:          strtostrptr(spaceGuid),
-						MtarPath:       strtostrptr(""),
-						DeployStrategy: strtostrptr(normalDeploy),
+						HclType:       hclObjectResource,
+						HclObjectName: "rs",
+						Space:         strtostrptr(spaceGuid),
+						MtarPath:      strtostrptr(""),
 					}),
 					ExpectError: regexp.MustCompile(`Unable to upload mtar file`),
 				},
 				{
 					Config: hclProvider(nil) + hclResourceMta(&MtaResourceModelPtr{
-						HclType:        hclObjectResource,
-						HclObjectName:  "rs",
-						Space:          strtostrptr(spaceGuid),
-						MtarPath:       strtostrptr("../../assets/provider-config-local.txt"),
-						DeployStrategy: strtostrptr(normalDeploy),
+						HclType:       hclObjectResource,
+						HclObjectName: "rs",
+						Space:         strtostrptr(spaceGuid),
+						MtarPath:      strtostrptr("../../assets/provider-config-local.txt"),
 					}),
 					ExpectError: regexp.MustCompile(`MTA ID missing`),
 				},
@@ -226,7 +218,6 @@ EOT
 						Space:                strtostrptr(spaceGuid),
 						MtarPath:             strtostrptr(mtarPath),
 						ExtensionDescriptors: strtostrptr(`["../../assets/pr"]`),
-						DeployStrategy:       strtostrptr(normalDeploy),
 					}),
 					ExpectError: regexp.MustCompile(`Unable to upload mta extension descriptor`),
 				},
@@ -237,7 +228,6 @@ EOT
 						Space:                strtostrptr(spaceGuid),
 						MtarPath:             strtostrptr(mtarPath),
 						ExtensionDescriptors: strtostrptr(`[""]`),
-						DeployStrategy:       strtostrptr(normalDeploy),
 					}),
 					ExpectError: regexp.MustCompile(`Unable to upload mta extension descriptor`),
 				},
@@ -248,7 +238,6 @@ EOT
 						Space:                strtostrptr(spaceGuid),
 						MtarPath:             strtostrptr(mtarPath),
 						ExtensionDescriptors: strtostrptr(`["../../assets/provider-config-local.txt"]`),
-						DeployStrategy:       strtostrptr(normalDeploy),
 					}),
 					ExpectError: regexp.MustCompile(`Failure in polling MTA operation`),
 				},
@@ -266,12 +255,11 @@ EOT
 			Steps: []resource.TestStep{
 				{
 					Config: hclProvider(nil) + hclResourceMta(&MtaResourceModelPtr{
-						HclType:        hclObjectResource,
-						HclObjectName:  "rs",
-						MtarPath:       strtostrptr(mtarPath),
-						Space:          strtostrptr(spaceGuid),
-						Namespace:      strtostrptr("Hello"),
-						DeployStrategy: strtostrptr(normalDeploy),
+						HclType:       hclObjectResource,
+						HclObjectName: "rs",
+						MtarPath:      strtostrptr(mtarPath),
+						Space:         strtostrptr(spaceGuid),
+						Namespace:     strtostrptr("Hello"),
 					}),
 					ExpectError: regexp.MustCompile(`Failure in polling MTA operation`),
 				},
@@ -289,11 +277,10 @@ EOT
 			Steps: []resource.TestStep{
 				{
 					Config: hclProvider(nil) + hclResourceMta(&MtaResourceModelPtr{
-						HclType:        hclObjectResource,
-						HclObjectName:  "rs",
-						Space:          strtostrptr(spaceGuid),
-						MtarUrl:        strtostrptr(""),
-						DeployStrategy: strtostrptr(normalDeploy),
+						HclType:       hclObjectResource,
+						HclObjectName: "rs",
+						Space:         strtostrptr(spaceGuid),
+						MtarUrl:       strtostrptr(""),
 					}),
 					ExpectError: regexp.MustCompile(`Unable to upload remote mtar file`),
 				},

--- a/cloudfoundry/provider/types_mta.go
+++ b/cloudfoundry/provider/types_mta.go
@@ -23,6 +23,8 @@ type MtarType struct {
 	DeployStrategy             types.String `tfsdk:"deploy_strategy"`
 	VersionRule                types.String `tfsdk:"version_rule"`
 	Modules                    types.Set    `tfsdk:"modules"`
+	SkipIdleStart              types.Bool   `tfsdk:"skip_idle_start"`
+	SkipTestingPhase           types.Bool   `tfsdk:"skip_testing_phase"`
 }
 
 type MtasDataSourceType struct {

--- a/docs/resources/mta.md
+++ b/docs/resources/mta.md
@@ -89,6 +89,8 @@ EOT
 - `mtar_path` (String) The local path where the MTA archive is present. Either this attribute or mtar_url need to be set.
 - `mtar_url` (String) The remote URL where the MTA archive is present
 - `namespace` (String) The namespace of the MTA. Should be of valid host format
+- `skip_idle_start` (Boolean) Skip the starting of the newly deployed applications on idle routes.
+- `skip_testing_phase` (Boolean) Choose to skip the testing phase and you will not be asked to manually confirm the deletion of the older version of the MTA applications.
 - `source_code_hash` (String) SHA256 hash of the file specified. Terraform relies on this to detect the file changes.
 - `version_rule` (String) The rule to apply to determine how the application version number is used to trigger an application-update deployment operation.
 


### PR DESCRIPTION
## Purpose

Currently, the deployment behaviour of the `mta` resource is slighty different from the multiapps-cli. This PR aligns it with the multiapps-cli

## Does this introduce a breaking change?

- [x] Yes
- [ ] No


## Pull Request Type

What kind of change does this Pull Request introduce?
<!-- Please check the one that applies to this PR using "X". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [x] Other... Please describe: Alignment across tools


## How to Test

- Test the code via automated test

```bash
go test ./...
```

## What to Check

Verify that the following are valid:

- Automated tests are executed successfully

## Other Information
<!-- Add any other helpful information that may be needed here. -->

## Checklist for reviewer

<!-- This checklist needs to completed by the reviewer of the PR -->
The following organizational tasks must be completed before merging this PR:

- [ ] The PR has the matching labels assigned to it.
- [ ] The PR has a milestone assigned to it.
- [ ] If the PR closes an issue, the issue is referenced.
- [ ] Possible follow-up items are created and linked.
