### PR TITLE
fix: set identity data during update for open tofu compatibility

### DIFF
--- a/cloudfoundry/provider/resource_buildpack.go
+++ b/cloudfoundry/provider/resource_buildpack.go
@@ -34,7 +34,7 @@ type BuildpackResource struct {
 	cfClient *cfv3client.Client
 }
 
-type buildpackResouerceIdentityModel struct {
+type buildpackResourceIdentityModel struct {
 	BuildpackGUID types.String `tfsdk:"buildpack_guid"`
 }
 
@@ -191,7 +191,7 @@ func (r *BuildpackResource) Create(ctx context.Context, req resource.CreateReque
 	tflog.Trace(ctx, "created a buildpack resource")
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 
-	identity := buildpackResouerceIdentityModel{
+	identity := buildpackResourceIdentityModel{
 		BuildpackGUID: types.StringValue(data.Id.ValueString()),
 	}
 
@@ -222,11 +222,11 @@ func (rs *BuildpackResource) Read(ctx context.Context, req resource.ReadRequest,
 	tflog.Trace(ctx, "read a buildpack resource")
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 
-	var identity buildpackResouerceIdentityModel
+	var identity buildpackResourceIdentityModel
 
 	diags = req.Identity.Get(ctx, &identity)
 	if diags.HasError() {
-		identity = buildpackResouerceIdentityModel{
+		identity = buildpackResourceIdentityModel{
 			BuildpackGUID: types.StringValue(data.Id.ValueString()),
 		}
 
@@ -295,6 +295,16 @@ func (rs *BuildpackResource) Update(ctx context.Context, req resource.UpdateRequ
 
 	tflog.Trace(ctx, "updated a buildpack resource")
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+
+	// WORKAROUND for OpenTofu compatibility
+	// https://github.com/cloudfoundry/terraform-provider-cloudfoundry/issues/418
+	identity := buildpackResourceIdentityModel{
+		BuildpackGUID: types.StringValue(data.Id.ValueString()),
+	}
+
+	diags = resp.Identity.Set(ctx, identity)
+	resp.Diagnostics.Append(diags...)
+	// END WORKAROUND
 }
 
 func (rs *BuildpackResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {

--- a/cloudfoundry/provider/resource_domain.go
+++ b/cloudfoundry/provider/resource_domain.go
@@ -273,6 +273,15 @@ func (rs *DomainResource) Update(ctx context.Context, req resource.UpdateRequest
 	tflog.Trace(ctx, "updated a domain resource")
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 
+	// WORKAROUND for OpenTofu compatibility
+	// https://github.com/cloudfoundry/terraform-provider-cloudfoundry/issues/418
+	identity := domainResouerceIdentityModel{
+		DomainGUID: types.StringValue(data.Id.ValueString()),
+	}
+
+	diags = resp.Identity.Set(ctx, identity)
+	resp.Diagnostics.Append(diags...)
+	// END WORKAROUND
 }
 
 func (rs *DomainResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {

--- a/cloudfoundry/provider/resource_isolation_segment.go
+++ b/cloudfoundry/provider/resource_isolation_segment.go
@@ -179,6 +179,16 @@ func (rs *IsolationSegmentResource) Update(ctx context.Context, req resource.Upd
 
 	tflog.Trace(ctx, "updated an isolation segment resource")
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+
+	// WORKAROUND for OpenTofu compatibility
+	// https://github.com/cloudfoundry/terraform-provider-cloudfoundry/issues/418
+	identity := isolationSegmentResouerceIdentityModel{
+		SegmentGUID: types.StringValue(data.Id.ValueString()),
+	}
+
+	diags = resp.Identity.Set(ctx, identity)
+	resp.Diagnostics.Append(diags...)
+	// END WORKAROUND
 }
 
 func (rs *IsolationSegmentResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {

--- a/cloudfoundry/provider/resource_org.go
+++ b/cloudfoundry/provider/resource_org.go
@@ -259,6 +259,15 @@ func (r *orgResource) Update(ctx context.Context, req resource.UpdateRequest, re
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 
+	// WORKAROUND for OpenTofu compatibility
+	// https://github.com/cloudfoundry/terraform-provider-cloudfoundry/issues/418
+	identity := OrgResouerceIdentityModel{
+		OrgGUID: types.StringValue(plan.ID.ValueString()),
+	}
+
+	diags = resp.Identity.Set(ctx, identity)
+	resp.Diagnostics.Append(diags...)
+	// END WORKAROUND
 }
 
 // Delete the resource and removes the Terraform state on success.

--- a/cloudfoundry/provider/resource_org_quota.go
+++ b/cloudfoundry/provider/resource_org_quota.go
@@ -166,7 +166,7 @@ func (r *orgQuotaResource) Create(ctx context.Context, req resource.CreateReques
 	}
 
 	identity := orgQuotaResouerceIdentityModel{
-		OrgQuotaGUID: types.StringValue(orgQuotaType.ID.ValueString()),
+		OrgQuotaGUID: types.StringValue(orgsQuotaType.ID.ValueString()),
 	}
 
 	diags = resp.Identity.Set(ctx, identity)
@@ -280,6 +280,16 @@ func (r *orgQuotaResource) Update(ctx context.Context, req resource.UpdateReques
 	if resp.Diagnostics.HasError() {
 		return
 	}
+
+	// WORKAROUND for OpenTofu compatibility
+	// https://github.com/cloudfoundry/terraform-provider-cloudfoundry/issues/418
+	identity := orgQuotaResouerceIdentityModel{
+		OrgQuotaGUID: types.StringValue(orgsQuotaType.ID.ValueString()),
+	}
+
+	diags = resp.Identity.Set(ctx, identity)
+	resp.Diagnostics.Append(diags...)
+	// END WORKAROUND
 }
 
 func (r *orgQuotaResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {

--- a/cloudfoundry/provider/resource_route.go
+++ b/cloudfoundry/provider/resource_route.go
@@ -331,6 +331,16 @@ func (rs *RouteResource) Update(ctx context.Context, req resource.UpdateRequest,
 
 	tflog.Trace(ctx, "updated a route resource")
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+
+	// WORKAROUND for OpenTofu compatibility
+	// https://github.com/cloudfoundry/terraform-provider-cloudfoundry/issues/418
+	identity := routeResouerceIdentityModel{
+		RouteGUID: types.StringValue(data.Id.ValueString()),
+	}
+
+	diags = resp.Identity.Set(ctx, identity)
+	resp.Diagnostics.Append(diags...)
+	// END WORKAROUND
 }
 
 func (rs *RouteResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {

--- a/cloudfoundry/provider/resource_security_group.go
+++ b/cloudfoundry/provider/resource_security_group.go
@@ -314,6 +314,15 @@ func (rs *SecurityGroupResource) Update(ctx context.Context, req resource.Update
 
 	tflog.Trace(ctx, "updated a security group resource")
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+
+	// WORKAROUND for OpenTofu compatibility
+	identity := securityGroupResouerceIdentityModel{
+		SecurityGroupGUID: types.StringValue(data.Id.ValueString()),
+	}
+
+	diags = resp.Identity.Set(ctx, identity)
+	resp.Diagnostics.Append(diags...)
+	// END WORKAROUND
 }
 
 func (rs *SecurityGroupResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {

--- a/cloudfoundry/provider/resource_space.go
+++ b/cloudfoundry/provider/resource_space.go
@@ -286,6 +286,15 @@ func (rs *SpaceResource) Update(ctx context.Context, req resource.UpdateRequest,
 	tflog.Trace(ctx, "updated a space resource")
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 
+	// WORKAROUND for OpenTofu compatibility
+	// https://github.com/cloudfoundry/terraform-provider-cloudfoundry/issues/418
+	identity := SpaceResouerceIdentityModel{
+		SpaceGUID: types.StringValue(data.Id.ValueString()),
+	}
+
+	diags = resp.Identity.Set(ctx, identity)
+	resp.Diagnostics.Append(diags...)
+	// END WORKAROUND
 }
 
 func (rs *SpaceResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {

--- a/cloudfoundry/provider/resource_space_quota.go
+++ b/cloudfoundry/provider/resource_space_quota.go
@@ -300,6 +300,16 @@ func (r *spaceQuotaResource) Update(ctx context.Context, req resource.UpdateRequ
 	if resp.Diagnostics.HasError() {
 		return
 	}
+
+	// WORKAROUND for OpenTofu compatibility
+	// https://github.com/cloudfoundry/terraform-provider-cloudfoundry/issues/418
+	identity := SpaceQuotaResouerceIdentityModel{
+		SpaceQuotaGUID: types.StringValue(spacesQuotaType.ID.ValueString()),
+	}
+
+	diags = resp.Identity.Set(ctx, identity)
+	resp.Diagnostics.Append(diags...)
+	// END WORKAROUND
 }
 
 func (r *spaceQuotaResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {

--- a/cloudfoundry/provider/resource_user.go
+++ b/cloudfoundry/provider/resource_user.go
@@ -299,6 +299,16 @@ func (rs *UserResource) Update(ctx context.Context, req resource.UpdateRequest, 
 
 	tflog.Trace(ctx, "updated a user resource")
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+
+	// WORKAROUND for OpenTofu compatibility
+	// https://github.com/cloudfoundry/terraform-provider-cloudfoundry/issues/418
+	identity := userResourceIdentityModel{
+		UserGUID: types.StringValue(data.Id.ValueString()),
+	}
+
+	diags = resp.Identity.Set(ctx, identity)
+	resp.Diagnostics.Append(diags...)
+	// END WORKAROUND
 }
 
 func (rs *UserResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {

--- a/cloudfoundry/provider/resource_user_cf.go
+++ b/cloudfoundry/provider/resource_user_cf.go
@@ -241,6 +241,16 @@ func (rs *UserCFResource) Update(ctx context.Context, req resource.UpdateRequest
 
 	tflog.Trace(ctx, "updated a cf user resource")
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+
+	// WORKAROUND for OpenTofu compatibility
+	// https://github.com/cloudfoundry/terraform-provider-cloudfoundry/issues/418
+	identity := userCfResourceIdentityModel{
+		UserGUID: types.StringValue(data.Id.ValueString()),
+	}
+
+	diags = resp.Identity.Set(ctx, identity)
+	resp.Diagnostics.Append(diags...)
+	// END WORKAROUND
 }
 
 func (rs *UserCFResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
- ensure identity is set during the update process for open tofu compatibility
- closes #418 

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No


## Pull Request Type

What kind of change does this Pull Request introduce?
<!-- Please check the one that applies to this PR using "X". -->

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:


## How to Test

- Test the code via automated test

```bash
go test ./...
```

## What to Check

Verify that the following are valid:

- Automated tests are executed successfully

## Other Information
<!-- Add any other helpful information that may be needed here. -->

## Checklist for reviewer

<!-- This checklist needs to completed by the reviewer of the PR -->
The following organizational tasks must be completed before merging this PR:

- [ ] The PR has the matching labels assigned to it.
- [ ] The PR has a milestone assigned to it.
- [ ] If the PR closes an issue, the issue is referenced.
- [ ] Possible follow-up items are created and linked.
