### PR TITLE
fix: resolve app crash while configuring readiness_health_check_invocation_timeout

### DIFF
--- a/cloudfoundry/provider/types_app.go
+++ b/cloudfoundry/provider/types_app.go
@@ -531,7 +531,9 @@ func mapAppValuesToType(ctx context.Context, appManifest *cfv3operation.AppManif
 					appType.ReadinessHealthCheckHttpEndpoint = types.StringValue(process.ReadinessHealthCheckHttpEndpoint)
 				}
 				if process.ReadinessHealthInvocationTimeout != 0 {
-					appType.ReadinessHealthCheckInvocationTimeout = types.Int64Value(int64(process.HealthCheckInvocationTimeout))
+					appType.ReadinessHealthCheckInvocationTimeout = types.Int64Value(int64(process.ReadinessHealthInvocationTimeout))
+				} else if !reqPlanType.ReadinessHealthCheckInvocationTimeout.IsNull() && !reqPlanType.ReadinessHealthCheckInvocationTimeout.IsUnknown() {
+					appType.ReadinessHealthCheckInvocationTimeout = reqPlanType.ReadinessHealthCheckInvocationTimeout
 				}
 				if process.ReadinessHealthCheckInterval != 0 {
 					appType.ReadinessHealthCheckInterval = types.Int64Value(int64(process.ReadinessHealthCheckInterval))
@@ -601,7 +603,9 @@ func mapAppValuesToType(ctx context.Context, appManifest *cfv3operation.AppManif
 					p.ReadinessHealthCheckHttpEndpoint = types.StringValue(process.ReadinessHealthCheckHttpEndpoint)
 				}
 				if process.ReadinessHealthInvocationTimeout != 0 {
-					p.ReadinessHealthCheckInvocationTimeout = types.Int64Value(int64(process.HealthCheckInvocationTimeout))
+					p.ReadinessHealthCheckInvocationTimeout = types.Int64Value(int64(process.ReadinessHealthInvocationTimeout))
+				} else if plannedProcess != nil && !plannedProcess.ReadinessHealthCheckInvocationTimeout.IsNull() && !plannedProcess.ReadinessHealthCheckInvocationTimeout.IsUnknown() {
+					p.ReadinessHealthCheckInvocationTimeout = plannedProcess.ReadinessHealthCheckInvocationTimeout
 				}
 				if process.ReadinessHealthCheckInterval != 0 {
 					p.ReadinessHealthCheckInterval = types.Int64Value(int64(process.ReadinessHealthCheckInterval))
@@ -857,7 +861,7 @@ func mapAppDatasourceValuesToType(ctx context.Context, appManifest *cfv3operatio
 				p.ReadinessHealthCheckHttpEndpoint = types.StringValue(process.ReadinessHealthCheckHttpEndpoint)
 			}
 			if process.ReadinessHealthInvocationTimeout != 0 {
-				p.ReadinessHealthCheckInvocationTimeout = types.Int64Value(int64(process.HealthCheckInvocationTimeout))
+				p.ReadinessHealthCheckInvocationTimeout = types.Int64Value(int64(process.ReadinessHealthInvocationTimeout))
 			}
 			if process.ReadinessHealthCheckInterval != 0 {
 				p.ReadinessHealthCheckInterval = types.Int64Value(int64(process.ReadinessHealthCheckInterval))


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
- This PR handles terraform failure when readiness_health_check_invocation_timeout is set in app configuration
- closes #529 

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No


## Pull Request Type

What kind of change does this Pull Request introduce?
<!-- Please check the one that applies to this PR using "X". -->

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:


## How to Test

- Test the code via automated test

```bash
go test ./...
```

## What to Check

Verify that the following are valid:

- Automated tests are executed successfully

## Other Information
<!-- Add any other helpful information that may be needed here. -->

## Checklist for reviewer

<!-- This checklist needs to completed by the reviewer of the PR -->
The following organizational tasks must be completed before merging this PR:

- [x] The PR has the matching labels assigned to it.
- [x] The PR has a milestone assigned to it.
- [x] If the PR closes an issue, the issue is referenced.
- [x] Possible follow-up items are created and linked.
