### PR TITLE
fix: cloudfoundry_app and cloudfoundry_apps datasource does not return instances attribute

### DIFF
--- a/cloudfoundry/provider/types_app.go
+++ b/cloudfoundry/provider/types_app.go
@@ -870,6 +870,23 @@ func mapAppDatasourceValuesToType(ctx context.Context, appManifest *cfv3operatio
 				p.LogRateLimitPerSecond = types.StringValue(process.LogRateLimitPerSecond)
 			}
 			processes = append(processes, p)
+			// Mirror the web process fields onto the top-level datasource attributes
+			if string(process.Type) == "web" {
+				appType.Command = p.Command
+				appType.DiskQuota = p.DiskQuota
+				appType.HealthCheckHttpEndpoint = p.HealthCheckHttpEndpoint
+				appType.HealthCheckInvocationTimeout = p.HealthCheckInvocationTimeout
+				appType.HealthCheckType = p.HealthCheckType
+				appType.Instances = p.Instances
+				appType.Memory = p.Memory
+				appType.Timeout = p.Timeout
+				appType.HealthCheckInterval = p.HealthCheckInterval
+				appType.ReadinessHealthCheckType = p.ReadinessHealthCheckType
+				appType.ReadinessHealthCheckHttpEndpoint = p.ReadinessHealthCheckHttpEndpoint
+				appType.ReadinessHealthCheckInvocationTimeout = p.ReadinessHealthCheckInvocationTimeout
+				appType.ReadinessHealthCheckInterval = p.ReadinessHealthCheckInterval
+				appType.LogRateLimitPerSecond = p.LogRateLimitPerSecond
+			}
 		}
 		appType.Processes = processes
 	}


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
- This PR fixes an issue where top-level process attributes in the cloudfoundry_app and cloudfoundry_apps data sources were always returned as null.
- The cloudfoundry_app and cloudfoundry_apps data sources expose top-level attributes from the web process (e.g. instances, memory, disk_quota, health_check_type, command, etc.) via datasourceProcessAppCommonSchema()
-  Although these attributes were defined in the schema, they were never populated from the corresponding web process, causing them to always return null.
- Now, after populating each Process struct in the loop, the web process fields are copied to the matching top-level fields on DatasourceAppType.
- closes #472 

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No


## Pull Request Type

What kind of change does this Pull Request introduce?
<!-- Please check the one that applies to this PR using "X". -->

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:


## How to Test

- Test the code via automated test

```bash
go test ./...
```

## What to Check

Verify that the following are valid:

- Automated tests are executed successfully

## Other Information
<!-- Add any other helpful information that may be needed here. -->

## Checklist for reviewer

<!-- This checklist needs to completed by the reviewer of the PR -->
The following organizational tasks must be completed before merging this PR:

- [x] The PR has the matching labels assigned to it.
- [x] The PR has a milestone assigned to it.
- [x] If the PR closes an issue, the issue is referenced.
- [x] Possible follow-up items are created and linked.
