### PR TITLE
feat: Make timeout for rolling strategy configurable

### DIFF
--- a/cloudfoundry/provider/resource_app.go
+++ b/cloudfoundry/provider/resource_app.go
@@ -573,9 +573,10 @@ func (r *appResource) push(appType AppType, appManifestValue *cfv3operation.AppM
 	if !appType.Strategy.IsNull() {
 		switch appType.Strategy.ValueString() {
 		case "rolling":
-			manifestOp.WithStrategy(cfv3operation.StrategyRolling)
+			timeout, checkInterval := r.getDeploymentStrategyOptions(appType)
+			manifestOp.WithRollingStrategy(timeout, checkInterval)
 		case "blue-green":
-			timeout, checkInterval := r.getBlueGreenDeploymentStrategyOptions(appType)
+			timeout, checkInterval := r.getDeploymentStrategyOptions(appType)
 			manifestOp.WithBlueGreenStrategy(timeout, checkInterval)
 		default:
 			manifestOp.WithStrategy(cfv3operation.StrategyNone)
@@ -594,7 +595,7 @@ func (r *appResource) push(appType AppType, appManifestValue *cfv3operation.AppM
 	return appResp, nil
 }
 
-func (r *appResource) getBlueGreenDeploymentStrategyOptions(appType AppType) (uint, uint) {
+func (r *appResource) getDeploymentStrategyOptions(appType AppType) (uint, uint) {
 	if appType.AppDeployedRunningTimeout.IsNull() && appType.AppDeployedRunningCheckInterval.IsNull() {
 		return AppDeployedRunningTimeoutMinutesFeatureNotUsed, AppDeployedRunningCheckIntervalSecondsFeatureNotUsed
 	}


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
- This PR makes the polling timeout for rolling deployments configurable.
- Currently, the rolling strategy uses a fixed timeout value while waiting for the deployment to complete. With this change, the timeout can be configured based on the application's requirements, providing more flexibility for deployments with different startup and readiness characteristics.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No


## Pull Request Type

What kind of change does this Pull Request introduce?
<!-- Please check the one that applies to this PR using "X". -->

- [ ] Bugfix
- [x] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:


## How to Test

- Test the code via automated test

```bash
go test ./...
```

## What to Check

Verify that the following are valid:

- Automated tests are executed successfully

## Other Information
<!-- Add any other helpful information that may be needed here. -->

## Checklist for reviewer

<!-- This checklist needs to completed by the reviewer of the PR -->
The following organizational tasks must be completed before merging this PR:

- [ ] The PR has the matching labels assigned to it.
- [ ] The PR has a milestone assigned to it.
- [ ] If the PR closes an issue, the issue is referenced.
- [ ] Possible follow-up items are created and linked.
