### PR TITLE
fix(provider): guard nil MaintenanceInfo on managed service instance create

### DIFF
--- a/cloudfoundry/provider/types_service_instance.go
+++ b/cloudfoundry/provider/types_service_instance.go
@@ -211,8 +211,12 @@ func mapResourceServiceInstanceValuesToType(ctx context.Context, value *resource
 		if value.DashboardURL != nil {
 			serviceInstanceType.DashboardURL = types.StringValue(*value.DashboardURL)
 		}
-		serviceInstanceType.MaintenanceInfo, diags = types.ObjectValueFrom(ctx, maintenanceInfoAttrTypes, mapMaintenanceInfo(*value.MaintenanceInfo))
-		diagnostics.Append(diags...)
+		if value.MaintenanceInfo != nil {
+			serviceInstanceType.MaintenanceInfo, diags = types.ObjectValueFrom(ctx, maintenanceInfoAttrTypes, mapMaintenanceInfo(*value.MaintenanceInfo))
+			diagnostics.Append(diags...)
+		} else {
+			serviceInstanceType.MaintenanceInfo = types.ObjectNull(maintenanceInfoAttrTypes)
+		}
 
 		if !paramCreds.IsNull() {
 			serviceInstanceType.Parameters = jsontypes.NewNormalizedValue(paramCreds.ValueString())

--- a/cloudfoundry/provider/types_service_instance_test.go
+++ b/cloudfoundry/provider/types_service_instance_test.go
@@ -1,0 +1,41 @@
+package provider
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/cloudfoundry/go-cfclient/v3/resource"
+	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
+)
+
+// Reproduces https://github.com/cloudfoundry/terraform-provider-cloudfoundry/issues/590:
+// the Cloud Controller API omits maintenance_info (json tag "omitempty") for some managed
+// service instances, and the resource mapper dereferenced it unconditionally, crashing the
+// provider with a nil pointer dereference during terraform apply.
+func TestMapResourceServiceInstanceValuesToType_NilMaintenanceInfo(t *testing.T) {
+	managedInstance := &resource.ServiceInstance{
+		Name: "tf-test-rds",
+		Type: managedSerivceInstance,
+		Relationships: resource.ServiceInstanceRelationships{
+			Space:       &resource.ToOneRelationship{Data: &resource.Relationship{GUID: "space-guid"}},
+			ServicePlan: &resource.ToOneRelationship{Data: &resource.Relationship{GUID: "plan-guid"}},
+		},
+		Metadata:        &resource.Metadata{},
+		MaintenanceInfo: nil,
+		Resource: resource.Resource{
+			GUID:      "instance-guid",
+			CreatedAt: time.Now(),
+			UpdatedAt: time.Now(),
+		},
+	}
+
+	result, diags := mapResourceServiceInstanceValuesToType(context.Background(), managedInstance, jsontypes.NewNormalizedNull())
+
+	if diags.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", diags)
+	}
+	if !result.MaintenanceInfo.IsNull() {
+		t.Errorf("expected MaintenanceInfo to be null when the API omits it, got %v", result.MaintenanceInfo)
+	}
+}


### PR DESCRIPTION
## Summary
Fixes #590. The Cloud Controller API omits `maintenance_info` (`json:"maintenance_info,omitempty"`) for some managed service instances. `mapResourceServiceInstanceValuesToType` dereferenced it unconditionally, crashing the provider with a nil pointer dereference during `terraform apply` (confirmed with the reporter's own reproduction: creating a cloud.gov `aws-rds` managed service instance).

The data-source mapper for the same field already guards against nil (`types_service_instance.go:155-159`); this brings the resource mapper in line with it, exactly matching the fix the issue reporter proposed.

## Test plan
- Added `TestMapResourceServiceInstanceValuesToType_NilMaintenanceInfo`, which reproduces the crash against the unfixed code (panics at the reported line) and passes after the fix.
- `go build ./...` and `go vet ./cloudfoundry/...` clean.
- `go test ./cloudfoundry/provider -run TestMapResourceServiceInstanceValuesToType_NilMaintenanceInfo -v` passes.

---

If this is useful, a mention or link back to my GitHub profile (github.com/holistis) would be appreciated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
